### PR TITLE
Add merkleX with support for USD markets

### DIFF
--- a/exchanges/__init__.py
+++ b/exchanges/__init__.py
@@ -9,3 +9,4 @@ from .idex import IDEXAPI
 from .ethex import EthexAPI
 from .coinexchange import CoinExchangeAPI
 from .uniswap import UniswapAPI
+from .merklex import MerkleXAPI

--- a/exchanges/merklex.py
+++ b/exchanges/merklex.py
@@ -1,0 +1,29 @@
+from .base_exchange import BaseExchangeAPI
+
+class MerkleXAPI(BaseExchangeAPI):
+    def __init__(self, currency_symbol):
+        super().__init__()
+
+        self._SERVER_URL = "https://api.merklex.io"
+        self.currency_symbol = currency_symbol
+        self.exchange_name = "merkleX"
+        self.command_names = ['merkleX', 
+                              'merklex', 
+                              'merkelx', 
+                              'mx']
+        self.short_url = "http://bit.ly/2G21Axc"
+
+    async def _update(self, timeout=10.0):
+        method = "/markets/%s-DAI/stats" % self.currency_symbol
+        data = await self._get_json_from_url(self._SERVER_URL+method)
+
+        try:
+            self.price_usd = float(data['last_trade']['price'])
+            self.volume_usd = float(data['volume']['quote_volume_24h'])
+        except TypeError as e:
+            raise TimeoutError("Could not convert data to float") from e
+
+if __name__ == "__main__":
+    api = MerkleXAPI('0xBTC')
+    api.load_once_and_print_values()
+

--- a/exchanges/multi_exchange_manager.py
+++ b/exchanges/multi_exchange_manager.py
@@ -14,7 +14,7 @@ _OLDEST_ALLOWED_DATA_SECONDS = 600
 class MultiExchangeManager():
     def __init__(self, api_obj_list):
         self.api_obj_list = api_obj_list
-    
+
     async def update(self):
         for api_obj in self.api_obj_list:
             report_success = api_obj.update_failure_count >= 2
@@ -93,10 +93,12 @@ class MultiExchangeManager():
                 continue
             if a.price_usd == None:
                 continue
-            if a.volume_eth == None:
-                continue
+            if a.volume_usd == None:
+                volume = 0
+            else:
+                volume = a.volume_usd
             if exchange_name == 'aggregate' or a.exchange_name == exchange_name:
-                result.add(a.price_usd, a.volume_eth)
+                result.add(a.price_usd, volume)
         return result.average()
 
     def volume_usd(self, currency_symbol, exchange_name='aggregate'):

--- a/main.py
+++ b/main.py
@@ -497,6 +497,7 @@ def main():
         exchanges.EthexAPI(config.TOKEN_SYMBOL),
         exchanges.CoinExchangeAPI(config.TOKEN_SYMBOL),
         exchanges.UniswapAPI(config.TOKEN_SYMBOL),
+        exchanges.MerkleXAPI(config.TOKEN_SYMBOL),
     ])
     token = MineableTokenInfo(config.TOKEN_ETH_ADDRESS)
     storage = Storage(config.DATA_FOLDER)


### PR DESCRIPTION
- formats volume command to add each market on its own line.
- uses price_usd and volume_usd where appropriate

![Screenshot from 2019-07-08 16-16-01](https://user-images.githubusercontent.com/1400322/60848605-1a510c00-a19c-11e9-88b6-e52a28729b13.png)
